### PR TITLE
[feature] formatAssetDisplayValue - add humanize option

### DIFF
--- a/src/components/organisms/Vault/vault.organism.tsx
+++ b/src/components/organisms/Vault/vault.organism.tsx
@@ -489,7 +489,7 @@ const Vault: React.FC<IVaultProps> = (props) => {
                   </td>
                   <td>
                     <Skeleton loading={isFetchingAnyData}>
-                      ${formatAssetDisplayValue(tvl?.getValue())}
+                      {formatAssetDisplayValue(tvl?.getValue(), {humanize: true})}
                     </Skeleton>
                   </td>
                   <td>

--- a/src/components/pages/Vaults/vaults.page.tsx
+++ b/src/components/pages/Vaults/vaults.page.tsx
@@ -142,13 +142,13 @@ const VaultsPage: React.FC<RouteComponentProps<IVaultPageParams>> = (props) => {
               variant={ETypographyVariant.TITLE}
               element={"h3"}
             >
-              <Trans>TVL</Trans>&nbsp;${formatAssetDisplayValue(totalTvl.getValue())}
+              <Trans>TVL</Trans>&nbsp;{formatAssetDisplayValue(totalTvl.getValue(), {humanize: true})}
             </Typography>
             <Typography
               variant={ETypographyVariant.TITLE}
               element={"h5"}
             >
-              <Trans>Total Deposited Value</Trans>&nbsp;${formatAssetDisplayValue(totalDeposited.getValue())}
+              <Trans>Total Deposited Value</Trans>&nbsp;{formatAssetDisplayValue(totalDeposited.getValue(), {humanize: true})}
             </Typography>
           </div>
           { BANNER_ENABLED &&

--- a/src/shared/utils/common.util.ts
+++ b/src/shared/utils/common.util.ts
@@ -1,3 +1,4 @@
+import {i18n} from "@lingui/core";
 import BigDecimal from "js-big-decimal";
 import { BigNumber } from "ethers";
 
@@ -42,15 +43,19 @@ export function sleep(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-export function formatAssetDisplayValue(value: any) {
+export function humanizeValue(value: number) {
+  return i18n.number(value, { style: "currency", currency: "USD"});
+}
+
+export function formatAssetDisplayValue(value: any, options={humanize: false}) {
   if (isEmptyValue(value)) {
     return "-";
   } else {
-    // eslint-disable-next-line
+    // eslint-disable-next-line 
     if (value == 0) {
       return 0;
     } else {
-      return value;
+      return options.humanize ? humanizeValue(value) : value;
     }
   }
 }


### PR DESCRIPTION
# Changes

- formatAssetDisplayValue - add options param with default `{humanize: false}`
- humanizeValue function to format monetary values
- use `{humanize: true}` in `vault.organizsm.tsx` monetary values (tvl - per asset, tvl - chain, total deposited value)

<img width="1225" alt="image" src="https://user-images.githubusercontent.com/3539278/154742632-3b7cf7a5-303b-4a16-9aa4-94e8f0d58669.png">
