### PR TITLE
[fix] humanized zero values

### DIFF
--- a/src/shared/utils/common.util.ts
+++ b/src/shared/utils/common.util.ts
@@ -53,7 +53,7 @@ export function formatAssetDisplayValue(value: any, options={humanize: false}) {
   } else {
     // eslint-disable-next-line 
     if (value == 0) {
-      return 0;
+      return options.humanize ? "$0" : 0; 
     } else {
       return options.humanize ? humanizeValue(value) : value;
     }


### PR DESCRIPTION
# Changes

- retain `$` symbol when monetary value is 0

Before: 
<img width="478" alt="image" src="https://user-images.githubusercontent.com/3539278/155886097-96721727-ff45-4a1a-9f5c-38751f584337.png">

After:
<img width="503" alt="image" src="https://user-images.githubusercontent.com/3539278/155886138-92ef10b7-e925-4ac1-998c-decf652d8d0b.png">
