### PR TITLE
[fix] WalletConnect - hide change network button

### DIFF
--- a/src/components/organisms/CCDialog/ccDialog.organism.tsx
+++ b/src/components/organisms/CCDialog/ccDialog.organism.tsx
@@ -67,18 +67,19 @@ const ChainConstrainDialog: React.FC<IChainConstrainDialogProps> = (props) => {
         </Typography>
         <div className="d-flex">
           {
-            !isWalletConnect &&
-            <Button
-            theme={"tertiary"}
-            onClick={switchToChain(wantedNetwork)}
-            loading={isSwitchingNetwork}
-            >
-              <Typography>
-                <Trans>Switch to {wantedNetworkLabel} Network</Trans>
-              </Typography>
-            </Button>
+            !isWalletConnect && (
+              <Button
+              theme={"tertiary"}
+              onClick={switchToChain(wantedNetwork)}
+              loading={isSwitchingNetwork}
+              >
+                <Typography>
+                  <Trans>Switch to {wantedNetworkLabel} Network</Trans>
+                </Typography>
+              </Button>
+
+            )
           }
-          
           { (chainId && isChainSupported) &&
             <RouterLink to={getVaultPageRoute(chainId as EChainId)}>
               <Button

--- a/src/components/organisms/CCDialog/ccDialog.organism.tsx
+++ b/src/components/organisms/CCDialog/ccDialog.organism.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import useWeb3 from "../../../hooks/useWeb3";
+import { WalletConnectConnector } from "@web3-react/walletconnect-connector";
 import { useDispatch } from "react-redux";
 import { arbirtrayChainDataById } from "../../../shared/constants/web3.constants";
 import TextDialog from "../../atoms/TextDialog/textDialog.atom";
@@ -25,7 +26,8 @@ const ChainConstrainDialog: React.FC<IChainConstrainDialogProps> = (props) => {
   const {
     isChainSupported,
     chainId,
-    library
+    library,
+    connector,
   } = useWeb3();
 
   const switchToChain = (_chainId: number) => async () => {
@@ -40,6 +42,8 @@ const ChainConstrainDialog: React.FC<IChainConstrainDialogProps> = (props) => {
 
     setIsSwitchingNetwork(false);
   };
+
+  const isWalletConnect = connector && connector instanceof WalletConnectConnector;
 
   const dispatch = useDispatch();
   const [isSwitchingNetwork, setIsSwitchingNetwork] = useState<boolean>(false);
@@ -62,15 +66,19 @@ const ChainConstrainDialog: React.FC<IChainConstrainDialogProps> = (props) => {
           &nbsp;{networkError}
         </Typography>
         <div className="d-flex">
-          <Button
+          {
+            !isWalletConnect &&
+            <Button
             theme={"tertiary"}
             onClick={switchToChain(wantedNetwork)}
             loading={isSwitchingNetwork}
-          >
-            <Typography>
-              <Trans>Switch to {wantedNetworkLabel} Network</Trans>
-            </Typography>
-          </Button>
+            >
+              <Typography>
+                <Trans>Switch to {wantedNetworkLabel} Network</Trans>
+              </Typography>
+            </Button>
+          }
+          
           { (chainId && isChainSupported) &&
             <RouterLink to={getVaultPageRoute(chainId as EChainId)}>
               <Button

--- a/src/components/organisms/CCDialog/ccDialog.organism.tsx
+++ b/src/components/organisms/CCDialog/ccDialog.organism.tsx
@@ -69,9 +69,9 @@ const ChainConstrainDialog: React.FC<IChainConstrainDialogProps> = (props) => {
           {
             !isWalletConnect && (
               <Button
-              theme={"tertiary"}
-              onClick={switchToChain(wantedNetwork)}
-              loading={isSwitchingNetwork}
+                theme={"tertiary"}
+                onClick={switchToChain(wantedNetwork)}
+                loading={isSwitchingNetwork}
               >
                 <Typography>
                   <Trans>Switch to {wantedNetworkLabel} Network</Trans>


### PR DESCRIPTION
## Checklist (Mandatory):

- [x] I have named the PR correctly
- [x] I have tested new code locally
- [x] I have done a smoke test of the larger feature locally
- [x] I have added at least one reviewer
- [x] I have assigned the PR to myself
- [x] I have merged develop (parent) branch into my feature branch and resolved all conflicts
- [x] I have ensured any new UI changes comply with UX/UI designers 

## Checklist (Optional):

- [x] I have added necessary documentation, including instructions how to test
- [x] I have written the code according to the adopted style guide and linter doesn't fail
- [x] I have confirmed no errors were introduced in the developer console with the PR

## Additional notes

```
What does this implement/fix? Explain your changes.
- Hide change network button if in an unsupported network using wallet connect.
Are there any scripts that need running (eg. yarn install)?
Are there any edge cases that need checking?
- Change network button should be displayed if Unsupported network via Injected connection
Are there any specific test instructions?
Are there any Loom videos or screenshot that can be linked explaining the changes better?
```
<img width="1241" alt="image" src="https://user-images.githubusercontent.com/3539278/160351880-e28e5c07-0102-4de9-a8a0-77ccd8069cc6.png">